### PR TITLE
Generate assembly as regular jar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ val settings = Seq(
   assembly / assemblyOption := (assembly / assemblyOption).value.copy(includeScala = false),
   assembly / artifact := {
     val art = (assembly / artifact).value
-    art.withClassifier(Some("assembly"))
+    art.withClassifier(Some(""))
   },
   addArtifact(assembly / artifact, assembly)
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.2")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
-
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.2")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
- Updated build file to generate the assembly jar as a regular jar to avoid the classifier in SynapseML
- Updating the sbt plugin package.
- Tested in Databricks
![image](https://user-images.githubusercontent.com/98137159/221023994-26e0c5d5-d925-4805-aec0-658d9397c749.png)
![image](https://user-images.githubusercontent.com/98137159/221024066-a03e442c-8ad4-48cb-b2f3-9bed60f182de.png)

